### PR TITLE
Added missing StripVerificationAccount property to StripeAccount.

### DIFF
--- a/src/Stripe/StripeGateway.cs
+++ b/src/Stripe/StripeGateway.cs
@@ -11,7 +11,7 @@ using ServiceStack.Text;
 
 namespace ServiceStack.Stripe
 {
-    /* Charges 
+    /* Charges
 	 * https://stripe.com/docs/api/curl#charges
 	 */
     [Route("/charges")]
@@ -83,7 +83,7 @@ namespace ServiceStack.Stripe
         }
     }
 
-    /* Customers 
+    /* Customers
 	 * https://stripe.com/docs/api/curl#customers
 	 */
     [Route("/customers")]
@@ -408,8 +408,8 @@ namespace ServiceStack.Stripe
         public StripeCard Card { get; set; }
     }
 
-    /* 
-        Accounts 
+    /*
+        Accounts
     */
     [Route("/accounts")]
     public class CreateStripeAccount : IPost, IReturn<CreateStripeAccountResponse>
@@ -472,6 +472,7 @@ namespace ServiceStack.Stripe
         public string SupportUrl { get; set; }
         public string Timezone { get; set; }
         public StripeTosAcceptance TosAcceptance { get; set; }
+        public StripeVerificationAccount Verification { get; set; }
     }
 
     public class StripeDeclineCharge
@@ -533,7 +534,7 @@ namespace ServiceStack.Stripe
     public class StripeVerificationAccount
     {
         public string DisabledReason { get; set; }
-        public DateTime DueBy { get; set; }
+        public DateTime? DueBy { get; set; }
         public string[] FieldsNeeded { get; set; }
     }
 

--- a/tests/Stripe.Tests/StripeGatewayAccountTests.cs
+++ b/tests/Stripe.Tests/StripeGatewayAccountTests.cs
@@ -26,10 +26,10 @@ namespace Stripe.Tests
                         Country = "US",
                         PostalCode = "90210",
                     },
-                    Dob = new StripeDate(1980,1,1),
+                    Dob = new StripeDate(1980, 1, 1),
                     BusinessName = "Business Name",
                     FirstName = "First",
-                    LastName = "Last",                    
+                    LastName = "Last",
                 }
             });
 
@@ -57,6 +57,12 @@ namespace Stripe.Tests
             Assert.That(dob.Year, Is.EqualTo(1980));
             Assert.That(dob.Month, Is.EqualTo(1));
             Assert.That(dob.Day, Is.EqualTo(1));
+
+            var verification = response.Verification;
+            Assert.That(verification.DisabledReason, Is.EqualTo("fields_needed"));
+            Assert.That(verification.DueBy, Is.Null);
+            Assert.That(verification.FieldsNeeded, Is.Not.Null);
+            Assert.That(verification.FieldsNeeded.Length, Is.EqualTo(4));
         }
     }
 }


### PR DESCRIPTION
Added missing StripVerificationAccount property to StripeAccount.  This is included in the CreateAccount response for managed accounts and indicates which additional info is required. 

See https://stripe.com/docs/connect/updating-accounts#account-verification 